### PR TITLE
Replace outdated replace( a, b, c, -1) by replaceAll

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,11 +10,11 @@ func main() {
 }
 
 func outdatedReplace(s string) string {
-	return strings.Replace(s, "\\", "/", -1)
+	return strings.ReplaceAll(s, "\\", "/")
 }
 
 func outdatedReplace2(s string) string {
-	return strings.Replace(s, "\\", "/", -1)
+	return strings.ReplaceAll(s, "\\", "/")
 }
 
 func stringsContains(s, sub string) bool {


### PR DESCRIPTION
This batch change uses comby to replace the deprecated replace( a, b, c, -1) by replaceAll

[_Created by Sourcegraph batch change `joe/replace-all`._](https://sourcegraph.test:3443/users/joe/batch-changes/replace-all)